### PR TITLE
Fix MMD1 to MMD1F in phy_set_bits_mmd call

### DIFF
--- a/linux_drivers/dp83tc812.c
+++ b/linux_drivers/dp83tc812.c
@@ -488,7 +488,7 @@ static int DP83TC812_config_init(struct phy_device *phydev)
 			rgmii_delay |= DP83TC812_TX_CLK_SHIFT;
 
 		if (rgmii_delay) {
-			ret = phy_set_bits_mmd(phydev, MMD1,
+			ret = phy_set_bits_mmd(phydev, MMD1F,
 					       DP83TC812_RGMII_ID_CTRL,
 					       rgmii_delay);
 			if (ret)


### PR DESCRIPTION
Access to DP83TC812_RGMII_ID_CTRL is done via MMD1F (not MMD1 )